### PR TITLE
Fix cast check

### DIFF
--- a/tests/test_quotes.py
+++ b/tests/test_quotes.py
@@ -23,3 +23,10 @@ class QuotesTest(unittest.TestCase):
     def test_max_quotes(self):
         quotes = wikiquote.quotes('The Matrix (film)', max_quotes = 8)
         self.assertEqual(len(quotes), 8)
+
+    def test_is_cast_credit(self):
+      cast1 = 'Bryan Cranston - Walter White'.split()
+      cast2 = 'Giancarlo Esposito - Gustavo "Gus" Fring'.split()
+
+      self.assertTrue(wikiquote.is_cast_credit(cast1))
+      self.assertTrue(wikiquote.is_cast_credit(cast2))

--- a/wikiquote.py
+++ b/wikiquote.py
@@ -104,7 +104,7 @@ def quotes(page_title, max_quotes=DEFAULT_MAX_QUOTES):
 
     if is_disambiguation(data['parse']['categories']):
         raise DisambiguationPageException(
-                                       'Title returned a disambiguation page.')
+            'Title returned a disambiguation page.')
 
     html_content = data['parse']['text']['*']
     return extract_quotes(html_content, max_quotes)

--- a/wikiquote.py
+++ b/wikiquote.py
@@ -51,7 +51,8 @@ def is_cast_credit(txt_split):
         return False
 
     separators = ['as', '-', '–']
-    return all([w[0].isupper() or w in separators for w in txt_split])
+    return all([w[0].isupper() or w in separators or w[0] == '"'
+               for w in txt_split])
 
 
 def is_quote(txt):


### PR DESCRIPTION
Handle correctly the case of a cast name with double quotes in the beginning
e.g. 'Giancarlo Esposito - Gustavo "Gus" Fring'