### PR TITLE
Add random()

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Retrieve quotes from any Wikiquote.org page, or the quote of the day, with Pytho
 >>> wikiquote.quote_of_the_day() # returns a (quote, author) tuple
 # 'Always forgive your enemies; nothing annoys them so much.', 'Oscar Wilde'
 
+>>> wikiquote.random_titles(max_titles = 3) # max_titles defaults to 20
+# ['Dune', 'Johannes Kepler', 'Rosa Parks']
+
 >>> wikiquote.supported_languages()
 # ['en', 'fr']
 

--- a/tests/test_random_titles.py
+++ b/tests/test_random_titles.py
@@ -1,0 +1,17 @@
+import wikiquote
+import unittest
+
+class SearchTest(unittest.TestCase):
+    """
+    Test wikiquote.random_titles()
+    """
+
+    def test_random(self):
+        for lang in wikiquote.langs.SUPPORTED_LANGUAGES:
+            results = wikiquote.random_titles(lang=lang, max_titles=20)
+            self.assertTrue(len(results) == 20)
+
+    def test_unsupported_lang(self):
+        self.assertRaises(wikiquote.utils.UnsupportedLanguageException,
+                         wikiquote.random_titles,
+                         lang='hlhljopjpojkopijj')

--- a/wikiquote/__init__.py
+++ b/wikiquote/__init__.py
@@ -1,4 +1,4 @@
-from .quotes import quotes, search
+from .quotes import quotes, random_titles, search
 from .qotd import quote_of_the_day
 
 from . import langs

--- a/wikiquote/quotes.py
+++ b/wikiquote/quotes.py
@@ -24,6 +24,17 @@ def search(s, lang='en'):
     return results
 
 
+def random_titles(lang='en', max_titles=20):
+    if lang not in langs.SUPPORTED_LANGUAGES:
+        raise utils.UnsupportedLanguageException(
+            'Unsupported language: ' + lang)
+
+    local_random_url = utils.RANDOM_URL.format(lang=lang, limit=max_titles)
+    data = utils.json_from_url(local_random_url)
+    results = [entry['title'] for entry in data['query']['random']]
+    return results
+
+
 def quotes(page_title, max_quotes=utils.DEFAULT_MAX_QUOTES, lang='en'):
     if lang not in langs.SUPPORTED_LANGUAGES:
         raise utils.UnsupportedLanguageException(

--- a/wikiquote/utils.py
+++ b/wikiquote/utils.py
@@ -17,6 +17,8 @@ class UnsupportedLanguageException(Exception):
 
 W_URL = 'http://{lang}.wikiquote.org/w/api.php'
 SRCH_URL = W_URL + '?format=json&action=query&list=search&continue=&srsearch='
+RANDOM_URL = W_URL + \
+        '?format=json&action=query&list=random&rnnamespace=0&rnlimit={limit}'
 PAGE_URL = W_URL + '?format=json&action=parse&prop=text|categories&page='
 MAINPAGE_URL = W_URL + '?format=json&action=parse&prop=text&page='
 DEFAULT_MAX_QUOTES = 20


### PR DESCRIPTION
A new function that return X random page titles.

Sadly, some of them are empty stubs, or disambiguation pages.
I don't think the API supports filtering those out in advance.