### PR TITLE
Add Python version classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,8 @@ setup(
   download_url = 'https://github.com/federicotdn/python-wikiquotes/tarball/0.1.2',
   keywords = ['quotes', 'wikiquote', 'python', 'api', 'qotd'],
   license = 'MIT',
-  classifiers = [],
+  classifiers = [
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.4',
+  ],
 )


### PR DESCRIPTION
This adds the "Python 3" version classifier to setup.py - it's the common way to indicate the package works in Python 3 (and the lack of "2" indicates a lack of support for Python 2). It's also the search PyPI makes when you choose "[Python 3 Packages](https://pypi.python.org/pypi?:action=browse&c=533&show=all)" in the sidebar.

I also mention 3.4, which is the version I use the library with. It *probably works with lower versions as well. I think PyPI inserts the latest Python version automatically if no other version is specified. (As you can see on [wikiquote's 0.1.3 PyPI entry](https://pypi.python.org/pypi/wikiquote/0.1.3).

There's no documentation for this convention, as far as I can tell :(