### PR TITLE
Improvements to parsing English pages

### DIFF
--- a/wikiquote/langs/en.py
+++ b/wikiquote/langs/en.py
@@ -33,6 +33,11 @@ def is_quote(txt):
 def extract_quotes(tree, max_quotes):
     quotes_list = []
 
+    # Remove table of contents
+    toc_list = tree.xpath('//div[@id="toc"]')
+    for toc in toc_list:
+        toc.getparent().remove(toc)
+
     # List items inside unordered lists
     node_list = tree.xpath('//div/ul/li')
 

--- a/wikiquote/langs/en.py
+++ b/wikiquote/langs/en.py
@@ -53,7 +53,7 @@ def extract_quotes(tree, max_quotes):
 
     # Scan list items description tags inside description lists.
     # Also grab headlines to skip some sections.
-    node_list = tree.xpath('//div/ul/li|//div/dl/dd|//h2')
+    node_list = tree.xpath('//div/ul/li|//div/dl|//h2')
 
     # Skip all quotes above the first heading
     skip_to_next_heading = True
@@ -72,8 +72,24 @@ def extract_quotes(tree, max_quotes):
 
             continue
 
-        # Handle li/dd
+        # <dl>'s are assumed to be multi-line dialogue
+        if node.tag == 'dl':
+            dds = node.xpath('dd')
 
+            if not all(is_quote_node(dd) for dd in dds):
+                continue
+
+            full_dialogue = '\n'.join(
+                dd.text_content().strip()
+                for dd in dds)
+            quotes_list.append(full_dialogue)
+
+            if max_quotes == len(quotes_list):
+                break
+
+            continue
+
+        # Handle <li>'s
         uls = node.xpath('ul')
         for ul in uls:
             ul.getparent().remove(ul)

--- a/wikiquote/langs/en.py
+++ b/wikiquote/langs/en.py
@@ -14,8 +14,8 @@ def is_cast_credit(txt_split):
         return False
 
     separators = ['as', '-', '–']
-    return all([w[0].isupper() or w in separators or w[0] == '"'
-               for w in txt_split])
+    return all(w[0].isupper() or w in separators or w[0] == '"'
+               for w in txt_split)
 
 
 def is_quote(txt):
@@ -23,7 +23,7 @@ def is_quote(txt):
     invalid_conditions = [
         not txt or not txt[0].isupper() or len(txt) < MIN_QUOTE_LEN,
         len(txt_split) < MIN_QUOTE_WORDS,
-        any([True for word in txt_split if word in WORD_BLACKLIST]),
+        any(True for word in txt_split if word in WORD_BLACKLIST),
         txt.endswith(('(', ':', ']')),
         is_cast_credit(txt_split)
     ]

--- a/wikiquote/langs/en.py
+++ b/wikiquote/langs/en.py
@@ -42,12 +42,12 @@ def extract_quotes(tree, max_quotes):
     if len(dd_list) > len(node_list):
         node_list += dd_list
 
-    for txt in node_list:
-        uls = txt.xpath('ul')
+    for node in node_list:
+        uls = node.xpath('ul')
         for ul in uls:
             ul.getparent().remove(ul)
 
-        txt = txt.text_content().strip()
+        txt = node.text_content().strip()
         if is_quote(txt) and max_quotes > len(quotes_list):
             txt_normal = ' '.join(txt.split())
             quotes_list.append(txt_normal)

--- a/wikiquote/utils.py
+++ b/wikiquote/utils.py
@@ -19,7 +19,8 @@ W_URL = 'http://{lang}.wikiquote.org/w/api.php'
 SRCH_URL = W_URL + '?format=json&action=query&list=search&continue=&srsearch='
 RANDOM_URL = W_URL + \
         '?format=json&action=query&list=random&rnnamespace=0&rnlimit={limit}'
-PAGE_URL = W_URL + '?format=json&action=parse&prop=text|categories&page='
+PAGE_URL = W_URL + '?format=json&action=parse&prop=text|categories&' \
+        'disableeditsection&page='
 MAINPAGE_URL = W_URL + '?format=json&action=parse&prop=text&page='
 DEFAULT_MAX_QUOTES = 20
 


### PR DESCRIPTION
This is an attempt to fix various issues reported in #7 and some more discussed over email.

I did not add any tests (yet). I mostly tested it manually on these pages in the hope that they are representative:
* Dune
* George Washington
* The Warriors (film)
* Dinnerladies
* Good Morning, Vietnam
* Werner Erhard (60 Minutes)

The commits are pretty self-explanatory, so I won't go into details. Every change deals with something found in those pages. For example, "Dune" is the only page on Wikiquote with a "Related Wikipedia articles" headline. This isn't handled especially by the headline code, but the entries do get caught by the "entry is only a link" rule, and since the URL's are in italics, it requires recursion.